### PR TITLE
Fix crash with malformed gateways

### DIFF
--- a/lib/TBM/config_parser.rb
+++ b/lib/TBM/config_parser.rb
@@ -72,14 +72,14 @@ module TBM
 
 		def self.parse_gateway( gateway_name, targets, config )
 			if String === gateway_name
-				(gateway_host, gateway_username) = parse_gateway_name( gateway_name )
+				(gateway_host, gateway_username) = parse_gateway_name( gateway_name, config )
 				parse_targets( gateway_host, gateway_username, targets, config ) unless gateway_host.nil?
 			else
 				config.errors << "Cannot parse gateway name: #{gateway_name} (#{gateway_name.class})"
 			end
 		end
 
-		def self.parse_gateway_name( gateway_name )
+		def self.parse_gateway_name( gateway_name, config )
 			if GATEWAY_PATTERN =~ gateway_name
 				if $3.nil?
 					[$1,Etc.getlogin]

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -70,6 +70,13 @@ describe ConfigParser do
 				end
 			end
 
+			context "with a malformed gateway" do
+				let(:gateway) { "remote@user@gateway.example.com" }
+				let(:targets) { { 'web' => 80 } }
+				it { is_expected.not_to be_valid }
+				specify { expect(subject.errors).to include("Cannot parse gateway name: remote@user@gateway.example.com") }
+			end
+
 			context "keyed by a non-String" do
 				let(:gateway) { Array.new }
 				let(:targets) { Hash.new }
@@ -214,7 +221,7 @@ end
 RSpec::Matchers.define :have_tunnel do |expected|
 	match do |actual|
 		expect(actual).not_to be_nil
-		expect(actual.tunnels.size).to eql(1) 
+		expect(actual.tunnels.size).to eql(1)
 		tunnel = actual.tunnels[0]
 		expected.each do |k,v|
 			expect(tunnel.send(k)).to eql(v)


### PR DESCRIPTION
Fixes an issue with parsing malformed gateways, where the sequence of events
would try to add errors to a config object that wasn't passed into the
private parse_gateway_name method.

I didn't upgrade the version number because it looks like there hasn't been
a formal 0.5.0 release yet.
